### PR TITLE
Use logging and add command line options to server.

### DIFF
--- a/supplement/remote.py
+++ b/supplement/remote.py
@@ -8,16 +8,29 @@ from cPickle import dumps
 class Environment(object):
     """Supplement server client"""
 
-    def __init__(self, executable=None, env=None):
+    def __init__(self, executable=None, env=None, quiet=False, logfile=''):
         """Environment constructor
 
         :param executable: path to python executable. May be path to virtualenv interpreter
               start script like ``/path/to/venv/bin/python``.
 
         :param env: environment variables dict, e.g. ``DJANGO_SETTINGS_MODULE`` value.
+        
+        :param quiet: specifies if the server should not print any messages to
+                      the console.
+                      
+        :param logfile: A string specifying a path to a logfile to write all 
+                        logging messages to.
         """
         self.executable = executable or sys.executable
         self.env = env
+        
+        extra_args = []
+        if quiet:
+            extra_args.append('-q')
+        if len(logfile) > 0:
+            extra_args.extend(['-l', logfile])
+        self.extra_args = extra_args
 
         self.prepare_thread = None
         self.prepare_lock = Lock()
@@ -32,7 +45,7 @@ class Environment(object):
             addr = arbitrary_address('AF_UNIX')
 
         supp_server = os.path.join(os.path.dirname(__file__), 'server.py')
-        args = [self.executable, supp_server, addr]
+        args = [self.executable, supp_server, addr] + self.extra_args
 
         env = None
         if self.env:


### PR DESCRIPTION
- Supplement was printing exceptions using print statements and
  this has been changed to use the logging module instead.
- Using optparse to give the server a couple of command line arguments.
  "-q/--quiet" to suppress printing of error messages on the console
  and "-l FILE/--logfile=FILE" to write the log messages to the
  specified file.
- Added extra default arguments to the Environment class so that these
  are sent suitably to the server as command line arguments.  This
  allows a user to easily configure the logging and error reporting.
